### PR TITLE
Fixing typo in settings xml configuration node.

### DIFF
--- a/SXA.Theme.Optimizations/App_Config/Modules/SXA.Theme.Optimizations/SXA.Theme.Optimizations.config
+++ b/SXA.Theme.Optimizations/App_Config/Modules/SXA.Theme.Optimizations/SXA.Theme.Optimizations.config
@@ -2,8 +2,8 @@
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
 	<sitecore>
 		<settings>
-			<add key="SXA.Theme.Optimizations.GenerateScriptsOnStartup" value="true" role="ContentManagement or Standalone" />
-			<add key="SXA.Theme.Optimizations.GenerateScriptsOnStartup" value="false" role="ContentDelivery" />
+			<setting name="SXA.Theme.Optimizations.GenerateScriptsOnStartup" value="true" role="ContentManagement or Standalone" />
+			<setting name="SXA.Theme.Optimizations.GenerateScriptsOnStartup" value="false" role="ContentDelivery" />
 		</settings>
 		<services>
 			<configurator type="SXA.Theme.Optimizations.App_Start.Configurator, SXA.Theme.Optimizations" />


### PR DESCRIPTION
Pull request for open issue

[GenerateScriptsOnStartup Setting not found.](https://github.com/rbaconsulting/sxa-theme-optimizations/issues/30)